### PR TITLE
feat: allow user to focus back on popup

### DIFF
--- a/lua/overlook/api.lua
+++ b/lua/overlook/api.lua
@@ -51,9 +51,20 @@ end
 --- <
 ---@tag overlook-api.focus
 ---@toc_entry
-M.focus = function()
-  local stack = require("overlook.stack").get_current_stack()
-  stack:focus()
+M.switch_focus = function()
+  if not Stack.exists() or Stack.empty() then
+      vim.notify("Overlook: no popup to focus")
+    return
+  end
+  
+  local switch_to_winid = nil
+  if vim.w.is_overlook_popup then
+    switch_to_winid = vim.w.overlook_popup.root_winid
+  else then
+    switch_to_winid = Stack.top().winid
+  end
+  
+  pcall(api.nvim_set_current_win, switch_to_winid)
 end
 
 --- Peek at the current cursor position.

--- a/lua/overlook/api.lua
+++ b/lua/overlook/api.lua
@@ -40,7 +40,28 @@ M.peek_definition = function()
   Peek.definition()
 end
 
---- Focus on the topmost popup in the current window's stack.
+--- Switch focus between the top popup and the root window.
+---
+---@usage >lua
+---   vim.keymap.set("n", "<leader>pf", require("overlook.api").switch_focus)
+--- <
+---@tag overlook-api.switch_focus
+---@toc_entry
+M.switch_focus = function()
+  local switch_to_winid = nil
+  if vim.w.is_overlook_popup then
+    switch_to_winid = vim.w.overlook_popup.root_winid
+  elseif Stack.instances[vim.api.nvim_get_current_win()] and not Stack.empty() then
+    switch_to_winid = Stack.top().winid
+  end
+
+  if switch_to_winid == nil then
+    vim.notify("Overlook: no popup to focus")
+    return
+  end
+
+  pcall(vim.api.nvim_set_current_win, switch_to_winid)
+end
 ---
 --- Shifts window focus to the topmost popup in the current window's popup stack.
 --- This is useful when you need to interact with popup content after focusing

--- a/lua/overlook/api.lua
+++ b/lua/overlook/api.lua
@@ -62,31 +62,6 @@ M.switch_focus = function()
 
   pcall(vim.api.nvim_set_current_win, switch_to_winid)
 end
----
---- Shifts window focus to the topmost popup in the current window's popup stack.
---- This is useful when you need to interact with popup content after focusing
---- elsewhere in the window.
----
----@usage >lua
----   vim.keymap.set("n", "<leader>pf", require("overlook.api").focus)
---- <
----@tag overlook-api.focus
----@toc_entry
-M.switch_focus = function()
-  if not Stack.exists() or Stack.empty() then
-      vim.notify("Overlook: no popup to focus")
-    return
-  end
-  
-  local switch_to_winid = nil
-  if vim.w.is_overlook_popup then
-    switch_to_winid = vim.w.overlook_popup.root_winid
-  else then
-    switch_to_winid = Stack.top().winid
-  end
-  
-  pcall(api.nvim_set_current_win, switch_to_winid)
-end
 
 --- Peek at the current cursor position.
 ---

--- a/lua/overlook/api.lua
+++ b/lua/overlook/api.lua
@@ -40,6 +40,22 @@ M.peek_definition = function()
   Peek.definition()
 end
 
+--- Focus on the topmost popup in the current window's stack.
+---
+--- Shifts window focus to the topmost popup in the current window's popup stack.
+--- This is useful when you need to interact with popup content after focusing
+--- elsewhere in the window.
+---
+---@usage >lua
+---   vim.keymap.set("n", "<leader>pf", require("overlook.api").focus)
+--- <
+---@tag overlook-api.focus
+---@toc_entry
+M.focus = function()
+  local stack = require("overlook.stack").get_current_stack()
+  stack:focus()
+end
+
 --- Peek at the current cursor position.
 ---
 --- Creates a floating popup window at the current cursor position, displaying

--- a/lua/overlook/stack.lua
+++ b/lua/overlook/stack.lua
@@ -8,15 +8,6 @@ local api = vim.api
 local Stack = {}
 Stack.__index = Stack
 
----Focus the top popup in the stack.
----@return boolean
-function Stack:focus()
-    if self:empty() then
-        return false
-    end
-    return pcall(api.nvim_set_current_win, self:top().winid)
-end
-
 ---Returns the current size of the stack.
 ---@return integer
 function Stack:size()

--- a/lua/overlook/stack.lua
+++ b/lua/overlook/stack.lua
@@ -8,6 +8,15 @@ local api = vim.api
 local Stack = {}
 Stack.__index = Stack
 
+---Focus the top popup in the stack.
+---@return boolean
+function Stack:focus()
+    if self:empty() then
+        return false
+    end
+    return pcall(api.nvim_set_current_win, self:top().winid)
+end
+
 ---Returns the current size of the stack.
 ---@return integer
 function Stack:size()


### PR DESCRIPTION
In my workflow, I usually switch back to the main window and yank something or do some minor stuff before I want to get back to the popup. It's, of course, possible to kill the stack and then restore it again to get focus, but I thought it would be more flexible to allow the user to focus the popup with the API 👍 