### PR TITLE
feat: add title_pos ui option

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ require("overlook").setup({
     min_width = 10,                 -- Minimum popup width
     min_height = 3,                 -- Minimum popup height
     size_ratio = 0.65,              -- Default size ratio (0.0 to 1.0)
+    title_pos = "center",           -- Popup title position: "left", "center", or "right"
     keys = {
       close = "q",                  -- Key to close the topmost popup
     },

--- a/doc/overlook-config.txt
+++ b/doc/overlook-config.txt
@@ -66,6 +66,7 @@ Fields ~
 {min_width} `(integer)` Minimum allowed width for any popup window.
 {min_height} `(integer)` Minimum allowed height for any popup window.
 {size_ratio} `(number)` Default size ratio (0.0 to 1.0) used to calculate initial size.
+{title_pos} `("left"|"center"|"right")` Position of the popup title.
 {keys} `(optional)` `(table<string, string>)` Keymaps specific to the popup UI.
 
 ------------------------------------------------------------------------------
@@ -125,6 +126,9 @@ Type ~
 
       -- Default size ratio (0.0 to 1.0) used to calculate initial size.
       size_ratio = 0.65,
+
+      -- Position of the popup title. Accepts "left", "center", or "right".
+      title_pos = "center",
 
       -- Keymaps specific to the popup UI
       keys = {

--- a/lua/overlook/config.lua
+++ b/lua/overlook/config.lua
@@ -65,6 +65,7 @@ local M = {}
 ---@field min_width integer Minimum allowed width for any popup window.
 ---@field min_height integer Minimum allowed height for any popup window.
 ---@field size_ratio number Default size ratio (0.0 to 1.0) used to calculate initial size.
+---@field title_pos "left"|"center"|"right" Position of the popup title.
 ---@field keys? table<string, string> Keymaps specific to the popup UI.
 
 --- *OverlookOptions*
@@ -117,6 +118,9 @@ local defaults = {
 
     -- Default size ratio (0.0 to 1.0) used to calculate initial size.
     size_ratio = 0.65,
+
+    -- Position of the popup title. Accepts "left", "center", or "right".
+    title_pos = "center",
 
     -- Keymaps specific to the popup UI
     keys = {

--- a/lua/overlook/popup.lua
+++ b/lua/overlook/popup.lua
@@ -147,7 +147,7 @@ function Popup:determine_window_configuration(ctx)
   ---@diagnostic disable-next-line: assign-type-mismatch
   win_cfg.border = border
   win_cfg.title = self.opts.title or "Overlook default title"
-  win_cfg.title_pos = "center"
+  win_cfg.title_pos = Config.ui.title_pos
 
   self.win_config = win_cfg
   return true

--- a/tests/spec/popup_spec.lua
+++ b/tests/spec/popup_spec.lua
@@ -20,6 +20,7 @@ local initial_mock_ui_config_table = {
   col_offset = 1,
   row_offset = 1,
   size_ratio = 0.8,
+  title_pos = "center",
   min_width = 10,
   min_height = 5,
   width_decrement = 2,
@@ -96,6 +97,35 @@ describe("Popup -- border resolution fallback chain", function()
     local p = Popup.new { target_bufnr = make_real_buf(), lnum = 1, col = 1 }
     assert.is_not_nil(p)
     assert.are.equal("rounded", p.win_config.border)
+  end)
+end)
+
+describe("Popup -- title position", function()
+  local original_winbar
+  local function make_real_buf()
+    local b = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_lines(b, 0, -1, false, { "line" })
+    return b
+  end
+
+  before_each(function()
+    global_mock_config_module.reset_to_initial_state()
+    original_winbar = vim.o.winbar
+    vim.o.winbar = ""
+  end)
+
+  after_each(function()
+    global_mock_config_module.reset_to_initial_state()
+    vim.o.winbar = original_winbar
+  end)
+
+  it("uses Config.ui.title_pos for the popup title alignment", function()
+    global_mock_config_module.options.ui.title_pos = "right"
+
+    local p = Popup.new { target_bufnr = make_real_buf(), lnum = 1, col = 1 }
+
+    assert.is_not_nil(p)
+    assert.are.equal("right", p.win_config.title_pos)
   end)
 end)
 


### PR DESCRIPTION
Adds a `title_pos` ui option to control the popup title alignment. 

I find it easier to understand the file paths I'm tracing when they are aligned, but I did not find an option to change this.

Note: I used Claude to produce this change. I'm not experienced in nvim plugin development, but looking over the diff it looks to be a pretty straightforward change. I tested it locally and it works as intended. 

Thanks for making this plugin, it's really good. Please feel free to close this PR if this isn't something you are willing to accept.

<img width="1559" height="1440" alt="image" src="https://github.com/user-attachments/assets/4e97d927-502d-43af-8c61-626e196f7696" />